### PR TITLE
Prophet/configurable reporting level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.1.0
+### Configurable LogLevels
+You can now instanciate the Logger Destinations using the string or integer value of a given LogLevel.
+
+Library now targets .NetFramework 4.8, .NetStandard 2.1 .NetCore 3.1
+
+
 # v2.0.0
 ### LogLevel Overhaul and Specific LogLevel Targeting for Destinations
 Modified the actual values of the LogLevels enum values, setting them in Binary so it's easier to understand how 

--- a/ProphetsWay.Logger.Example/ProphetsWay.Logger.Example.csproj
+++ b/ProphetsWay.Logger.Example/ProphetsWay.Logger.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProphetsWay.Logger.Test/AdvancedTests.cs
+++ b/ProphetsWay.Logger.Test/AdvancedTests.cs
@@ -7,9 +7,9 @@ using Xunit;
 
 namespace ProphetsWay.Logger.Test
 {
-    [Collection("Logger is a Singleton")]
-    public class AdvancedTests
-    {
+	[Collection("Logger is a Singleton")]
+	public class AdvancedTests
+	{
 		[Fact]
 		public void ShouldTriggerProperlyWhenError()
 		{
@@ -92,48 +92,48 @@ namespace ProphetsWay.Logger.Test
 
 
 		private readonly Dictionary<LogLevels, bool> _triggers = new Dictionary<LogLevels, bool>();
-        private readonly Dictionary<LogLevels, BaseLoggingDestination> _destinations = new Dictionary<LogLevels, BaseLoggingDestination>();
+		private readonly Dictionary<LogLevels, BaseLoggingDestination> _destinations = new Dictionary<LogLevels, BaseLoggingDestination>();
 
-        private void SetupTriggers()
-        {
-            foreach (LogLevels num in Enum.GetValues(typeof(LogLevels)))
-            {
-                _triggers.Add(num, false);
-                var ev = new EventDestination(num);
-                ev.LoggingEvent += (sender, args) => _triggers[num] = true;
-                Utilities.Logger.AddDestination(ev);
-                _destinations.Add(num, ev);
-            }
-        }
+		private void SetupTriggers()
+		{
+			foreach (LogLevels num in Enum.GetValues(typeof(LogLevels)))
+			{
+				_triggers.Add(num, false);
+				var ev = new EventDestination(num);
+				ev.LoggingEvent += (sender, args) => _triggers[num] = true;
+				Utilities.Logger.AddDestination(ev);
+				_destinations.Add(num, ev);
+			}
+		}
 
-        private void CleanupTriggers()
-        {
-            _triggers.Clear();
+		private void CleanupTriggers()
+		{
+			_triggers.Clear();
 
-            foreach (var dest in _destinations.Values)
-                Utilities.Logger.RemoveDestination(dest);
+			foreach (var dest in _destinations.Values)
+				Utilities.Logger.RemoveDestination(dest);
 
-            _destinations.Clear();
-        }
+			_destinations.Clear();
+		}
 
-        private void AssertTriggers(bool err, bool warn, bool sec, bool info, bool debug, bool oWarn, bool oSec, bool oInfo, bool oDebug)
-        {
-            AssertTrigger(err, LogLevels.Error);
-            AssertTrigger(warn, LogLevels.Warning);
-            AssertTrigger(sec, LogLevels.Security);
-            AssertTrigger(info, LogLevels.Information);
-            AssertTrigger(debug, LogLevels.Debug);
-            AssertTrigger(oWarn, LogLevels.WarningOnly);
-            AssertTrigger(oSec, LogLevels.SecurityOnly);
-            AssertTrigger(oInfo, LogLevels.InformationOnly);
-            AssertTrigger(oDebug, LogLevels.DebugOnly);
-        }
+		private void AssertTriggers(bool err, bool warn, bool sec, bool info, bool debug, bool oWarn, bool oSec, bool oInfo, bool oDebug)
+		{
+			AssertTrigger(err, LogLevels.Error);
+			AssertTrigger(warn, LogLevels.Warning);
+			AssertTrigger(sec, LogLevels.Security);
+			AssertTrigger(info, LogLevels.Information);
+			AssertTrigger(debug, LogLevels.Debug);
+			AssertTrigger(oWarn, LogLevels.WarningOnly);
+			AssertTrigger(oSec, LogLevels.SecurityOnly);
+			AssertTrigger(oInfo, LogLevels.InformationOnly);
+			AssertTrigger(oDebug, LogLevels.DebugOnly);
+		}
 
-        private void AssertTrigger(bool expected, LogLevels checkLevel)
-        {
-            var because = $"{checkLevel} should have reported as '{expected}'";
-            _triggers[checkLevel].Should().Be(expected, because);
-        }
+		private void AssertTrigger(bool expected, LogLevels checkLevel)
+		{
+			var because = $"{checkLevel} should have reported as '{expected}'";
+			_triggers[checkLevel].Should().Be(expected, because);
+		}
 
-    }
+	}
 }

--- a/ProphetsWay.Logger.Test/BasicTests.cs
+++ b/ProphetsWay.Logger.Test/BasicTests.cs
@@ -70,5 +70,89 @@ namespace ProphetsWay.Logger.Test
             //cleanup
             Utilities.Logger.RemoveDestination(d);
         }
+
+        [Fact]
+        public void ShouldContainMessageLevelNamed()
+        {
+            //setup
+            const string msg = "Hello World!";
+            var evtMessage = string.Empty;
+            var d = new EventDestination("Debug");
+            d.LoggingEvent += (sender, args) => evtMessage = args.Message;
+            Utilities.Logger.AddDestination(d);
+
+            //act
+            Utilities.Logger.Debug(msg);
+
+
+            //assert 
+            evtMessage.Should().Contain(msg);
+
+            //cleanup
+            Utilities.Logger.RemoveDestination(d);
+        }
+
+        [Fact]
+        public void ShouldNotContainMessageLevelNamed()
+        {
+            //setup
+            const string msg = "Hello World!";
+            var evtMessage = string.Empty;
+            var d = new EventDestination("NOT_VALID");
+            d.LoggingEvent += (sender, args) => evtMessage = args.Message;
+            Utilities.Logger.AddDestination(d);
+
+            //act
+            Utilities.Logger.Debug(msg);
+
+
+            //assert 
+            evtMessage.Should().NotContain(msg);
+
+            //cleanup
+            Utilities.Logger.RemoveDestination(d);
+        }
+
+        [Fact]
+        public void ShouldContainMessageLevelInt()
+        {
+            //setup
+            const string msg = "Hello World!";
+            var evtMessage = string.Empty;
+            var d = new EventDestination(LogLevels.Debug.GetHashCode());
+            d.LoggingEvent += (sender, args) => evtMessage = args.Message;
+            Utilities.Logger.AddDestination(d);
+
+            //act
+            Utilities.Logger.Debug(msg);
+
+
+            //assert 
+            evtMessage.Should().Contain(msg);
+
+            //cleanup
+            Utilities.Logger.RemoveDestination(d);
+        }
+
+        [Fact]
+        public void ShouldNotContainMessageLevelInt()
+        {
+            //setup
+            const string msg = "Hello World!";
+            var evtMessage = string.Empty;
+            var d = new EventDestination(-1);
+            d.LoggingEvent += (sender, args) => evtMessage = args.Message;
+            Utilities.Logger.AddDestination(d);
+
+            //act
+            Utilities.Logger.Debug(msg);
+
+
+            //assert 
+            evtMessage.Should().NotContain(msg);
+
+            //cleanup
+            Utilities.Logger.RemoveDestination(d);
+        }
     }
 }

--- a/ProphetsWay.Logger.Test/ILoggingDestinationTests.cs
+++ b/ProphetsWay.Logger.Test/ILoggingDestinationTests.cs
@@ -15,7 +15,7 @@ namespace ProphetsWay.Logger.Test
 			const string msg = "Hello World!";
 			var mDest = new Mock<ILoggingDestination>();
 			mDest.Setup(dest => dest.Log(LogLevels.DebugOnly, msg, null)).Verifiable();
-            mDest.Setup(dest => dest.ValidateMessageLevel(LogLevels.DebugOnly)).Returns(true).Verifiable();
+			mDest.Setup(dest => dest.ValidateMessageLevel(LogLevels.DebugOnly)).Returns(true).Verifiable();
 			Utilities.Logger.AddDestination(mDest.Object);
 
 			//act
@@ -28,24 +28,24 @@ namespace ProphetsWay.Logger.Test
 			Utilities.Logger.RemoveDestination(mDest.Object);
 		}
 
-        [Fact]
-        public void ShouldTriggerLogMethodOnGenericIDestination()
-        {
-            //setup
-            const string msg = "Hello World!";
-            var mDest = new Mock<ILoggingDestination<bool>>();
-            mDest.Setup(dest => dest.Log(LogLevels.DebugOnly, true, msg, null)).Verifiable();
-            mDest.Setup(dest => dest.ValidateMessageLevel(LogLevels.DebugOnly)).Returns(true).Verifiable();
-            Utilities.Logger.AddDestination(mDest.Object);
+		[Fact]
+		public void ShouldTriggerLogMethodOnGenericIDestination()
+		{
+			//setup
+			const string msg = "Hello World!";
+			var mDest = new Mock<ILoggingDestination<bool>>();
+			mDest.Setup(dest => dest.Log(LogLevels.DebugOnly, true, msg, null)).Verifiable();
+			mDest.Setup(dest => dest.ValidateMessageLevel(LogLevels.DebugOnly)).Returns(true).Verifiable();
+			Utilities.Logger.AddDestination(mDest.Object);
 
-            //act
-            Utilities.Logger.Debug(msg, true);
+			//act
+			Utilities.Logger.Debug(msg, true);
 
-            //assert
-            mDest.VerifyAll();
+			//assert
+			mDest.VerifyAll();
 
-            //cleanup
-            Utilities.Logger.RemoveDestination(mDest.Object);
-        }
-    }
+			//cleanup
+			Utilities.Logger.RemoveDestination(mDest.Object);
+		}
+	}
 }

--- a/ProphetsWay.Logger.Test/ProphetsWay.Logger.Test.csproj
+++ b/ProphetsWay.Logger.Test/ProphetsWay.Logger.Test.csproj
@@ -1,23 +1,27 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net452;net46;net461;net471;netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;</TargetFrameworks>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>
+			net45;net451;net452;net46;net461;net471;net48;
+			netstandard2.0;netstandard2.1;
+			netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;netcoreapp3.0;netcoreapp3.1;
+		</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="FluentAssertions" Version="5.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+		<PackageReference Include="Moq" Version="4.10.1" />
+		<PackageReference Include="xunit" Version="2.4.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\ProphetsWay.Logger\ProphetsWay.Logger.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\ProphetsWay.Logger\ProphetsWay.Logger.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/ProphetsWay.Logger/BaseLoggingDestination.cs
+++ b/ProphetsWay.Logger/BaseLoggingDestination.cs
@@ -8,10 +8,12 @@ namespace ProphetsWay.Utilities
 	public abstract class BaseLoggingDestination : LoggingDestinationCore, ILoggingDestination
 	{
         protected BaseLoggingDestination(LogLevels reportingLevel) : base(reportingLevel) { }
+		protected BaseLoggingDestination(string strReportingLevel) : base(strReportingLevel) { }
+		protected BaseLoggingDestination(int intReportingLevel) : base(intReportingLevel) { }
 
-        /// <summary>
-        /// This is the required method from the ILoggingDestinations interface, this is the entry point for the destination from the Logger static class.
-        /// </summary>
-        public abstract void Log(LogLevels level, string message = null, Exception ex = null);
+		/// <summary>
+		/// This is the required method from the ILoggingDestinations interface, this is the entry point for the destination from the Logger static class.
+		/// </summary>
+		public abstract void Log(LogLevels level, string message = null, Exception ex = null);
 	}
 }

--- a/ProphetsWay.Logger/BaseLoggingDestination.cs
+++ b/ProphetsWay.Logger/BaseLoggingDestination.cs
@@ -7,7 +7,7 @@ namespace ProphetsWay.Utilities
 	/// </summary>
 	public abstract class BaseLoggingDestination : LoggingDestinationCore, ILoggingDestination
 	{
-        protected BaseLoggingDestination(LogLevels reportingLevel) : base(reportingLevel) { }
+		protected BaseLoggingDestination(LogLevels reportingLevel) : base(reportingLevel) { }
 		protected BaseLoggingDestination(string strReportingLevel) : base(strReportingLevel) { }
 		protected BaseLoggingDestination(int intReportingLevel) : base(intReportingLevel) { }
 

--- a/ProphetsWay.Logger/Generics/BaseLoggingDestination.cs
+++ b/ProphetsWay.Logger/Generics/BaseLoggingDestination.cs
@@ -2,18 +2,18 @@
 
 namespace ProphetsWay.Utilities.Generics
 {
-    /// <summary>
+	/// <summary>
 	/// A Base class for creating new custom Generic ILoggingDestinations, all you need to implement is the Log method
 	/// </summary>
-    public abstract class BaseLoggingDestination<T> : LoggingDestinationCore, ILoggingDestination<T>
-    {
-        protected BaseLoggingDestination(LogLevels reportingLevel) : base(reportingLevel) { }
-        protected BaseLoggingDestination(string strReportingLevel) : base(strReportingLevel) { }
-        protected BaseLoggingDestination(int intReportingLevel) : base(intReportingLevel) { }
+	public abstract class BaseLoggingDestination<T> : LoggingDestinationCore, ILoggingDestination<T>
+	{
+		protected BaseLoggingDestination(LogLevels reportingLevel) : base(reportingLevel) { }
+		protected BaseLoggingDestination(string strReportingLevel) : base(strReportingLevel) { }
+		protected BaseLoggingDestination(int intReportingLevel) : base(intReportingLevel) { }
 
-        /// <summary>
+		/// <summary>
 		/// This is the required method from the ILoggingDestinations interface, this is the entry point for the destination from the Logger static class.
 		/// </summary>
-        public abstract void Log(LogLevels level, T metadata, string message = null, Exception ex = null);
-    }
+		public abstract void Log(LogLevels level, T metadata, string message = null, Exception ex = null);
+	}
 }

--- a/ProphetsWay.Logger/Generics/BaseLoggingDestination.cs
+++ b/ProphetsWay.Logger/Generics/BaseLoggingDestination.cs
@@ -8,6 +8,8 @@ namespace ProphetsWay.Utilities.Generics
     public abstract class BaseLoggingDestination<T> : LoggingDestinationCore, ILoggingDestination<T>
     {
         protected BaseLoggingDestination(LogLevels reportingLevel) : base(reportingLevel) { }
+        protected BaseLoggingDestination(string strReportingLevel) : base(strReportingLevel) { }
+        protected BaseLoggingDestination(int intReportingLevel) : base(intReportingLevel) { }
 
         /// <summary>
 		/// This is the required method from the ILoggingDestinations interface, this is the entry point for the destination from the Logger static class.

--- a/ProphetsWay.Logger/Logger.cs
+++ b/ProphetsWay.Logger/Logger.cs
@@ -6,18 +6,18 @@ namespace ProphetsWay.Utilities
 {
 	public static partial class Logger
 	{
-        //private static readonly IList<ILoggingDestination> Destinations = new List<ILoggingDestination>();
-        private static readonly Type _nonGenericTypDestination = typeof(ILoggingDestination);
-        /// <summary>
-        /// Will add a new LoggingDestination to the pool of targets.  
-        /// </summary>
-        /// <param name="newDest">Either an existing or a custom Destination that implements the ILoggingDestination interface.</param>
-        public static void AddDestination(ILoggingDestination newDest)
+		//private static readonly IList<ILoggingDestination> Destinations = new List<ILoggingDestination>();
+		private static readonly Type _nonGenericTypDestination = typeof(ILoggingDestination);
+		/// <summary>
+		/// Will add a new LoggingDestination to the pool of targets.  
+		/// </summary>
+		/// <param name="newDest">Either an existing or a custom Destination that implements the ILoggingDestination interface.</param>
+		public static void AddDestination(ILoggingDestination newDest)
 		{
-            if (!Destinations.ContainsKey(_nonGenericTypDestination))
-                Destinations.Add(_nonGenericTypDestination, new List<IDestination>());
+			if (!Destinations.ContainsKey(_nonGenericTypDestination))
+				Destinations.Add(_nonGenericTypDestination, new List<IDestination>());
 
-            Destinations[_nonGenericTypDestination].Add(newDest);
+			Destinations[_nonGenericTypDestination].Add(newDest);
 		}
 
 		/// <summary>
@@ -26,18 +26,18 @@ namespace ProphetsWay.Utilities
 		/// <param name="destToRemove">Either an existing or a custom Destination that implements the ILoggingDestination interface; must have already been added to the pool via "AddDestination".</param>
 		public static void RemoveDestination(ILoggingDestination destToRemove)
 		{
-            if (Destinations.ContainsKey(_nonGenericTypDestination))
-                Destinations[_nonGenericTypDestination].Remove(destToRemove);
-        }
+			if (Destinations.ContainsKey(_nonGenericTypDestination))
+				Destinations[_nonGenericTypDestination].Remove(destToRemove);
+		}
 
 		/// <summary>
 		/// Resets the pool of targets, removes any/all Destinations that have been added.
 		/// </summary>
 		public static void ClearDestinations()
 		{
-            if (Destinations.ContainsKey(_nonGenericTypDestination))
-                Destinations[_nonGenericTypDestination].Clear();
-        }
+			if (Destinations.ContainsKey(_nonGenericTypDestination))
+				Destinations[_nonGenericTypDestination].Clear();
+		}
 
 		/// <summary>
 		/// Now hidden, you shouldn't need to use this method directly, only use the shortcut methods below
@@ -47,15 +47,15 @@ namespace ProphetsWay.Utilities
 		/// <param name="ex">Optional, pass if you have an exception you want to add to the log entry.</param>
 		private static void Log(LogLevels level, string message, Exception ex = null)
 		{
-            if (!Destinations.ContainsKey(_nonGenericTypDestination))
-                Destinations.Add(_nonGenericTypDestination, new List<IDestination>());
+			if (!Destinations.ContainsKey(_nonGenericTypDestination))
+				Destinations.Add(_nonGenericTypDestination, new List<IDestination>());
 
-            if (Destinations[_nonGenericTypDestination].Count == 0)
+			if (Destinations[_nonGenericTypDestination].Count == 0)
 				AddDestination(new FileDestination($"Default Log {DateTime.Now:yyyy-MM-dd hh-mm}.log"));
 
-            foreach (ILoggingDestination dest in Destinations[_nonGenericTypDestination])
-                if (dest.ValidateMessageLevel(level))
-                    dest.Log(level, message, ex);
+			foreach (ILoggingDestination dest in Destinations[_nonGenericTypDestination])
+				if (dest.ValidateMessageLevel(level))
+					dest.Log(level, message, ex);
 		}
 
 		/// <summary>

--- a/ProphetsWay.Logger/LoggerDestinations/ConsoleDestination.cs
+++ b/ProphetsWay.Logger/LoggerDestinations/ConsoleDestination.cs
@@ -13,10 +13,34 @@ namespace ProphetsWay.Utilities.LoggerDestinations{
 		/// </summary>
 		/// <param name="reportingLevel">The severity level that you wish to have messages logged to the console.</param>
 		/// <param name="wrapper">Wrapper for the Console.WriteLine method, allow for customization and Unit Testing. (not required)</param>
-		public ConsoleDestination(LogLevels reportingLevel = LogLevels.Debug, ConsoleWrapper wrapper = null) : base(
-			reportingLevel)
+		public ConsoleDestination(LogLevels reportingLevel = LogLevels.Debug, ConsoleWrapper wrapper = null) : base(reportingLevel)
 		{
-			_wrapper = wrapper ?? new ConsoleWrapper();
+			_wrapper = UseOrCreateWrapper(wrapper);
+		}
+
+		/// <summary>
+		/// A basic destination that simply prints the log statements out to the Console.
+		/// </summary>
+		/// <param name="strReportingLevel">The string representation of the severity level that you wish to have messages logged to the console.</param>
+		/// <param name="wrapper">Wrapper for the Console.WriteLine method, allow for customization and Unit Testing. (not required)</param>
+		public ConsoleDestination(string strReportingLevel, ConsoleWrapper wrapper = null) : base(strReportingLevel)
+		{
+			_wrapper = UseOrCreateWrapper(wrapper);
+		}
+
+		/// <summary>
+		/// A basic destination that simply prints the log statements out to the Console.
+		/// </summary>
+		/// <param name="intReportingLevel">The integer representation of the severity level that you wish to have messages logged to the console.</param>
+		/// <param name="wrapper">Wrapper for the Console.WriteLine method, allow for customization and Unit Testing. (not required)</param>
+		public ConsoleDestination(int intReportingLevel, ConsoleWrapper wrapper = null) : base(intReportingLevel) 
+		{
+			_wrapper = UseOrCreateWrapper(wrapper);
+		}
+
+		private ConsoleWrapper UseOrCreateWrapper(ConsoleWrapper wrapper)
+		{
+			return wrapper ?? new ConsoleWrapper();
 		}
 
 		protected override void PrintLogEntry(string message)

--- a/ProphetsWay.Logger/LoggerDestinations/EventDestination.cs
+++ b/ProphetsWay.Logger/LoggerDestinations/EventDestination.cs
@@ -23,15 +23,15 @@ namespace ProphetsWay.Utilities.LoggerDestinations
 		public EventDestination(int intReportingLevel) : base(intReportingLevel) { }
 
 		public override void Log(LogLevels level, string message = null, Exception ex = null)
-        {
-            var evt = new LoggerEventArgs(MassageLogStatement(level, message,ex), level, message, ex);
-            LoggingEvent?.Invoke(this, evt);
-        }
+		{
+			var evt = new LoggerEventArgs(MassageLogStatement(level, message,ex), level, message, ex);
+			LoggingEvent?.Invoke(this, evt);
+		}
 
-        /// <summary>
-        /// The event you must subscribe to, to receive the relevant log events.
-        /// </summary>
-        public EventHandler<LoggerEventArgs> LoggingEvent;
+		/// <summary>
+		/// The event you must subscribe to, to receive the relevant log events.
+		/// </summary>
+		public EventHandler<LoggerEventArgs> LoggingEvent;
 
 		public class LoggerEventArgs : EventArgs
 		{

--- a/ProphetsWay.Logger/LoggerDestinations/EventDestination.cs
+++ b/ProphetsWay.Logger/LoggerDestinations/EventDestination.cs
@@ -10,12 +10,19 @@ namespace ProphetsWay.Utilities.LoggerDestinations
 		/// <summary>
 		/// A basic destination meant for use in situations that require events to be invoked (ie: UI applications).
 		/// </summary>
-		public EventDestination(LogLevels reportingLevel) : base(reportingLevel)
-		{
+		public EventDestination(LogLevels reportingLevel) : base(reportingLevel) { }
 
-		}
+		/// <summary>
+		/// A basic destination meant for use in situations that require events to be invoked (ie: UI applications).
+		/// </summary>
+		public EventDestination(string strReportingLevel) : base(strReportingLevel) { }
 
-        public override void Log(LogLevels level, string message = null, Exception ex = null)
+		/// <summary>
+		/// A basic destination meant for use in situations that require events to be invoked (ie: UI applications).
+		/// </summary>
+		public EventDestination(int intReportingLevel) : base(intReportingLevel) { }
+
+		public override void Log(LogLevels level, string message = null, Exception ex = null)
         {
             var evt = new LoggerEventArgs(MassageLogStatement(level, message,ex), level, message, ex);
             LoggingEvent?.Invoke(this, evt);

--- a/ProphetsWay.Logger/LoggerDestinations/FileDestination.cs
+++ b/ProphetsWay.Logger/LoggerDestinations/FileDestination.cs
@@ -24,47 +24,86 @@ namespace ProphetsWay.Utilities.LoggerDestinations
 			: base(reportingLevel)
 		{
 			_fi = new FileInfo(fileName);
+			_encoder = GetEncoding(encoder);
 
-			switch(encoder){
+			InitFile(resetFile);
+		}
+
+		/// <summary>
+		/// A basic destination that will write your logs to a File on the hard disk.
+		/// </summary>
+		/// <param name="fileName">The target file for writing the logs to.</param>
+		/// <param name="strReportingLevel">The string representation of the level or levels that this destination should write log statements for.</param>
+		/// <param name="resetFile">Default: true - will delete the current log file if it exists and recreate it.</param>
+		/// <param name="encoder">Default: UTF8 - allows user to specify what encoding pattern to use when writing the output file.</param>
+		public FileDestination(string fileName, string strReportingLevel, bool resetFile = true, EncodingOptions encoder = EncodingOptions.UTF8)
+			: base(strReportingLevel)
+		{
+			_fi = new FileInfo(fileName);
+			_encoder = GetEncoding(encoder);
+
+			InitFile(resetFile);
+		}
+
+		/// <summary>
+		/// A basic destination that will write your logs to a File on the hard disk.
+		/// </summary>
+		/// <param name="fileName">The target file for writing the logs to.</param>
+		/// <param name="intReportingLevel">The integer representation of the level or levels that this destination should write log statements for.</param>
+		/// <param name="resetFile">Default: true - will delete the current log file if it exists and recreate it.</param>
+		/// <param name="encoder">Default: UTF8 - allows user to specify what encoding pattern to use when writing the output file.</param>
+		public FileDestination(string fileName, int intReportingLevel, bool resetFile = true, EncodingOptions encoder = EncodingOptions.UTF8)
+			: base(intReportingLevel)
+		{
+			_fi = new FileInfo(fileName);
+			_encoder = GetEncoding(encoder);
+
+			InitFile(resetFile);
+		}
+
+		private Encoding GetEncoding(EncodingOptions encodingOption)
+		{
+			switch (encodingOption)
+			{
 				case EncodingOptions.ASCII:
-					_encoder = Encoding.ASCII;
-					break;
-				
+					return Encoding.ASCII;
+
 				case EncodingOptions.BigEndianUnicode:
-					_encoder = Encoding.BigEndianUnicode;
-					break;
+					return Encoding.BigEndianUnicode;
 
 				case EncodingOptions.UTF32:
-					_encoder = Encoding.UTF32;
-					break;
+					return Encoding.UTF32;
 
 				case EncodingOptions.UTF7:
-					_encoder = Encoding.UTF7;
-					break;
+					return Encoding.UTF7;
 
 				case EncodingOptions.UTF8:
-					_encoder = Encoding.UTF8;
-					break;
+					return Encoding.UTF8;
 
 				case EncodingOptions.Unicode:
-					_encoder = Encoding.Unicode;
-					break;
-			}
+					return Encoding.Unicode;
 
-			try{
-				if(_fi.Exists && resetFile)
+				default:
+					return null;
+			}
+		}
+
+		private void InitFile(bool resetFile)
+		{
+			try
+			{
+				if (_fi.Exists && resetFile)
 					_fi.Delete();
 
-				if(!(_fi.Directory?.Exists).GetValueOrDefault())
+				if (!(_fi.Directory?.Exists).GetValueOrDefault())
 					_fi.Directory?.Create();
 			}
-			catch(Exception ex)
+			catch (Exception ex)
 			{
 				Console.WriteLine(ex.Message);
 				throw;
 			}
 		}
-
 
 		protected override void PrintLogEntry(string message)
 		{

--- a/ProphetsWay.Logger/LoggerDestinations/GenericEventDestination.cs
+++ b/ProphetsWay.Logger/LoggerDestinations/GenericEventDestination.cs
@@ -15,6 +15,16 @@ namespace ProphetsWay.Utilities.LoggerDestinations
 		/// </summary>
         public GenericEventDestination(LogLevels reportingLevel) : base(reportingLevel) { }
 
+        /// <summary>
+		/// A basic destination meant for use in situations that require events to be invoked (ie: UI applications).
+		/// </summary>
+        public GenericEventDestination(string strReportingLevel) : base(strReportingLevel) { }
+
+        /// <summary>
+		/// A basic destination meant for use in situations that require events to be invoked (ie: UI applications).
+		/// </summary>
+        public GenericEventDestination(int intReportingLevel) : base(intReportingLevel) { }
+
         public override void Log(LogLevels level, T metadata, string message = null, Exception ex = null)
         {
             var evt = new LoggerEventArgs(message, level, ex, metadata, MassageLogStatement(level, message, ex));

--- a/ProphetsWay.Logger/LoggerDestinations/TextBasedDestination.cs
+++ b/ProphetsWay.Logger/LoggerDestinations/TextBasedDestination.cs
@@ -15,7 +15,9 @@ namespace ProphetsWay.Utilities.LoggerDestinations
             PrintLogEntry(msg);
         }
 
-        protected TextBasedDestination(LogLevels reportingLevel) : base(reportingLevel){}
+		protected TextBasedDestination(LogLevels reportingLevel) : base(reportingLevel) { }
+		protected TextBasedDestination(string strReportingLevel) : base(strReportingLevel) { }
+		protected TextBasedDestination(int intReportingLevel) : base(intReportingLevel) { }
 
 		protected abstract void PrintLogEntry(string message);
 	}

--- a/ProphetsWay.Logger/LoggingDestinationCore.cs
+++ b/ProphetsWay.Logger/LoggingDestinationCore.cs
@@ -2,105 +2,105 @@
 
 namespace ProphetsWay.Utilities
 {
-    /// <summary>
-    /// Core functionality that all Logging destinations will need to use, 
-    /// manages log level comparison in a single location,
-    /// includes a LoggerLock for use if needed in any inheriting destination.
-    /// </summary>
-    public abstract class LoggingDestinationCore : IDestination
-    {
-        public LoggingDestinationCore(LogLevels reportingLevel)
-        {
-            _reportingLevel = reportingLevel;
-        }
+	/// <summary>
+	/// Core functionality that all Logging destinations will need to use, 
+	/// manages log level comparison in a single location,
+	/// includes a LoggerLock for use if needed in any inheriting destination.
+	/// </summary>
+	public abstract class LoggingDestinationCore : IDestination
+	{
+		public LoggingDestinationCore(LogLevels reportingLevel)
+		{
+			_reportingLevel = reportingLevel;
+		}
 
-        public LoggingDestinationCore(string strReportingLevel)
-        {
-            _reportingLevel = ParseReportingLevel(strReportingLevel);   
-        }
+		public LoggingDestinationCore(string strReportingLevel)
+		{
+			_reportingLevel = ParseReportingLevel(strReportingLevel);   
+		}
 
-        public LoggingDestinationCore(int intReportingLevel)
-        {
-            var strReportingLevel = Enum.GetName(typeof(LogLevels), intReportingLevel);
-            _reportingLevel = ParseReportingLevel(strReportingLevel);
-        }
+		public LoggingDestinationCore(int intReportingLevel)
+		{
+			var strReportingLevel = Enum.GetName(typeof(LogLevels), intReportingLevel);
+			_reportingLevel = ParseReportingLevel(strReportingLevel);
+		}
 
-        private LogLevels ParseReportingLevel(string strReportingLevel)
-        {
-            if (Enum.TryParse(strReportingLevel, out LogLevels reportinglevel))
-                return reportinglevel;
-            else
-                return LogLevels.Information;
-        }
+		private LogLevels ParseReportingLevel(string strReportingLevel)
+		{
+			if (Enum.TryParse(strReportingLevel, out LogLevels reportinglevel))
+				return reportinglevel;
+			else
+				return LogLevels.Information;
+		}
 
-        /// <summary>
-        /// A lock object for use in making threadsafe destinations
-        /// </summary>
-        protected readonly object LoggerLock = new object();
+		/// <summary>
+		/// A lock object for use in making threadsafe destinations
+		/// </summary>
+		protected readonly object LoggerLock = new object();
 
-        private readonly LogLevels _reportingLevel;
+		private readonly LogLevels _reportingLevel;
 
-        /// <summary>
+		/// <summary>
 		/// This method is meant to massage the statement to be logged, before it goes to the WriteLogEntry method.
 		/// It will extract the details from an exception and add them to the end of the message.
 		/// It is Virtual and can be overridden if you wish to customize how you handle writing the raw Log method call.
 		/// This method calls WriteLogEntry.
 		/// </summary>
 		protected virtual string MassageLogStatement(LogLevels level, string message = null, Exception ex = null)
-        {
-            string exMessage, exStackTrace, massagedMessage = null;
+		{
+			string exMessage, exStackTrace, massagedMessage = null;
 
-            switch (level)
-            {
-                case LogLevels.Error:
-                    ExceptionDetailer(ex, out exMessage, out exStackTrace);
-                    massagedMessage = $"{message}{Environment.NewLine}{exMessage}{Environment.NewLine}{exStackTrace}";
-                    break;
+			switch (level)
+			{
+				case LogLevels.Error:
+					ExceptionDetailer(ex, out exMessage, out exStackTrace);
+					massagedMessage = $"{message}{Environment.NewLine}{exMessage}{Environment.NewLine}{exStackTrace}";
+					break;
 
-                case LogLevels.Warning:
-                    if (ex != null)
-                    {
-                        ExceptionDetailer(ex, out exMessage, out exStackTrace);
-                        massagedMessage = $"{message}{Environment.NewLine}{exMessage}{Environment.NewLine}{exStackTrace}";
-                    }
-                    break;
+				case LogLevels.Warning:
+					if (ex != null)
+					{
+						ExceptionDetailer(ex, out exMessage, out exStackTrace);
+						massagedMessage = $"{message}{Environment.NewLine}{exMessage}{Environment.NewLine}{exStackTrace}";
+					}
+					break;
 
-                default:
-                    massagedMessage = message;
-                    break;
-            }
+				default:
+					massagedMessage = message;
+					break;
+			}
 
-            return massagedMessage;
-        }
+			return massagedMessage;
+		}
 
-        /// <summary>
-        /// Recursive function to peer deep into an Exception and its Inner Exceptions to capture the messages and stack traces within.
-        /// </summary>
-        private static void ExceptionDetailer(Exception ex, out string message, out string stack)
-        {
-            var imessage = string.Empty;
-            var istack = string.Empty;
+		/// <summary>
+		/// Recursive function to peer deep into an Exception and its Inner Exceptions to capture the messages and stack traces within.
+		/// </summary>
+		private static void ExceptionDetailer(Exception ex, out string message, out string stack)
+		{
+			var imessage = string.Empty;
+			var istack = string.Empty;
 
-            if (ex.InnerException != null)
-                ExceptionDetailer(ex.InnerException, out imessage, out istack);
+			if (ex.InnerException != null)
+				ExceptionDetailer(ex.InnerException, out imessage, out istack);
 
-            message = string.IsNullOrEmpty(imessage)
-                ? ex.Message
-                : string.Format("{0}{1}{1}Inner Exception Message:{1}{2}", ex.Message, Environment.NewLine, imessage);
+			message = string.IsNullOrEmpty(imessage)
+				? ex.Message
+				: string.Format("{0}{1}{1}Inner Exception Message:{1}{2}", ex.Message, Environment.NewLine, imessage);
 
-            stack = string.IsNullOrEmpty(istack)
-                ? ex.StackTrace
-                : string.Format("{0}{1}{1}Inner Exception Stack Trace:{1}{2}", ex.StackTrace, Environment.NewLine, istack);
-        }
+			stack = string.IsNullOrEmpty(istack)
+				? ex.StackTrace
+				: string.Format("{0}{1}{1}Inner Exception Stack Trace:{1}{2}", ex.StackTrace, Environment.NewLine, istack);
+		}
 
 
-        /// <summary>
-        /// Returns true if the messageLevel matches the level specified when the Destination was created.
-        /// </summary>
-        public bool ValidateMessageLevel(LogLevels messageLevel)
-        {
-            //if the level of the message being passed is lower than the ReportingLevel set on the Destination, then return and don't log the message
-            return (messageLevel & _reportingLevel) == messageLevel;
-        }
-    }
+		/// <summary>
+		/// Returns true if the messageLevel matches the level specified when the Destination was created.
+		/// </summary>
+		public bool ValidateMessageLevel(LogLevels messageLevel)
+		{
+			//if the level of the message being passed is lower than the ReportingLevel set on the Destination, then return and don't log the message
+			return (messageLevel & _reportingLevel) == messageLevel;
+		}
+	}
 }

--- a/ProphetsWay.Logger/LoggingDestinationCore.cs
+++ b/ProphetsWay.Logger/LoggingDestinationCore.cs
@@ -14,6 +14,25 @@ namespace ProphetsWay.Utilities
             _reportingLevel = reportingLevel;
         }
 
+        public LoggingDestinationCore(string strReportingLevel)
+        {
+            _reportingLevel = ParseReportingLevel(strReportingLevel);   
+        }
+
+        public LoggingDestinationCore(int intReportingLevel)
+        {
+            var strReportingLevel = Enum.GetName(typeof(LogLevels), intReportingLevel);
+            _reportingLevel = ParseReportingLevel(strReportingLevel);
+        }
+
+        private LogLevels ParseReportingLevel(string strReportingLevel)
+        {
+            if (Enum.TryParse(strReportingLevel, out LogLevels reportinglevel))
+                return reportinglevel;
+            else
+                return LogLevels.Information;
+        }
+
         /// <summary>
         /// A lock object for use in making threadsafe destinations
         /// </summary>

--- a/ProphetsWay.Logger/ProphetsWay.Logger.csproj
+++ b/ProphetsWay.Logger/ProphetsWay.Logger.csproj
@@ -1,15 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net40;net45;net451;net452;net46;net461;net471;netstandard1.3;netstandard1.6;netstandard2.0;netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;netcoreapp1.1;netcoreapp1.0</TargetFrameworks>
+		<TargetFrameworks>
+			net40;net45;net451;net452;net46;net461;net471;net48;
+			netstandard1.3;netstandard1.6;netstandard2.0;netstandard2.1;
+			netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;netcoreapp1.1;netcoreapp1.0;netcoreapp3.0;netcoreapp3.1;
+		</TargetFrameworks>
 		<RootNamespace>ProphetsWay.Utilities</RootNamespace>
 		<AssemblyName>ProphetsWay.Logger</AssemblyName>
 		<ApplicationIcon />
 		<Win32Resource />
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 		<SignAssembly>false</SignAssembly>
-    
-    <Description>
+	
+	<Description>
 A simple and easy to use Logging library that allows for customizable outputs for log entries.
 
 Go to https://github.com/ProphetManX/ProphetsWay.Logger for more information.
@@ -22,28 +26,28 @@ add "using ProphetsWay.Utilities;" to your class
 and then you can call the Logger directly.
 Logger.AddDestination(new ConsoleDestination());
 Logger.Debug("Hello World!");
-    </Description>
+	</Description>
 
-    <!-- Assembly Override Properties -->
-    <PackageRequireLicenseAcceptance />
-    <PackageId />
-    <Version />
-    <Authors />
-    <Company />
-    <Product />
+	<!-- Assembly Override Properties -->
+	<PackageRequireLicenseAcceptance />
+	<PackageId />
+	<Version />
+	<Authors />
+	<Company />
+	<Product />
 
-    <Copyright />
-    <PackageLicenseUrl />
-    <PackageProjectUrl />
-    <PackageIconUrl />
-    <RepositoryUrl />
-    <RepositoryType />
-    <PackageTags />
-    <PackageReleaseNotes />
-    <NeutralLanguage />
-    <AssemblyVersion />
-    <FileVersion />
-    <InformationalVersion />
+	<Copyright />
+	<PackageLicenseUrl />
+	<PackageProjectUrl />
+	<PackageIconUrl />
+	<RepositoryUrl />
+	<RepositoryType />
+	<PackageTags />
+	<PackageReleaseNotes />
+	<NeutralLanguage />
+	<AssemblyVersion />
+	<FileVersion />
+	<InformationalVersion />
 		
 	</PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # ProphetsWay.Logger    
 
-| Release   | Status |
-|   ---     |  ---   |
-| Latest Build: | [![Build status](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_apis/build/status/Logger/Logger%20CI)](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_build/latest?definitionId=5)
-| Alpha:    | [![Build status](https://vsrm.dev.azure.com/ProphetsWay/_apis/public/Release/badge/dadb23ce-840b-4b7d-9783-dc5e9a2d9029/3/3)](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_release?definitionId=3)
-| Beta:     | [![Build status](https://vsrm.dev.azure.com/ProphetsWay/_apis/public/Release/badge/dadb23ce-840b-4b7d-9783-dc5e9a2d9029/3/10)](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_release?definitionId=3)
-| Release:  | [![Build status](https://vsrm.dev.azure.com/ProphetsWay/_apis/public/Release/badge/dadb23ce-840b-4b7d-9783-dc5e9a2d9029/3/11)](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_release?definitionId=3)
+| Master Build Status | NuGet Alpha | NuGet Beta | Nuget Release |
+|   ---   |   ---   |   ---   |   ---   |
+| [![Build status](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_apis/build/status/Logger/Logger%20CI)](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_build/?definitionId=5)| [![Build status](https://vsrm.dev.azure.com/ProphetsWay/_apis/public/Release/badge/dadb23ce-840b-4b7d-9783-dc5e9a2d9029/3/3)](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_release?definitionId=3)| [![Build status](https://vsrm.dev.azure.com/ProphetsWay/_apis/public/Release/badge/dadb23ce-840b-4b7d-9783-dc5e9a2d9029/3/10)](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_release?definitionId=3)| [![Build status](https://vsrm.dev.azure.com/ProphetsWay/_apis/public/Release/badge/dadb23ce-840b-4b7d-9783-dc5e9a2d9029/3/11)](https://dev.azure.com/ProphetsWay/ProphetsWay%20GitHub%20Projects/_release?definitionId=3)
 
 
 Logger is a quick to setup logging utility.  It is designed so that you can establish the destinations for your 
@@ -117,17 +114,17 @@ specific database destination that is tightly coupled to a solution you are work
 The BaseLoggingDestination requires an argument of LogLevel to be established, so any log statement with a 
 severity of what was chosen or higher will be logged at that destination.  The log levels are as follows:
 
-    Debug        - All LogLevels will log to this level
-    Information  - Everything but Debug messages will log to this level
-    Security     - Error, Warning, and Security messages will log to this level
-    Warning      - Only Warnings and Errors 
-    Error        - Only Errors will log to this level
+	Debug        - All LogLevels will log to this level
+	Information  - Everything but Debug messages will log to this level
+	Security     - Error, Warning, and Security messages will log to this level
+	Warning      - Only Warnings and Errors 
+	Error        - Only Errors will log to this level
 
-    //added in 2.0 new LogLevels
-    DebugOnly         - Will only accept Debug level messages
-    InformationOnly   - Will only accept Information level messages
-    SecurityOnly      - Will only accept Security level messages
-    WarningOnly       - Will only accept Warning level messages
+	//added in 2.0 new LogLevels
+	DebugOnly         - Will only accept Debug level messages
+	InformationOnly   - Will only accept Information level messages
+	SecurityOnly      - Will only accept Security level messages
+	WarningOnly       - Will only accept Warning level messages
 
 If your curious why there isn't an "ErrorOnly" option, that's because Error already works that way.
 
@@ -167,11 +164,11 @@ public class MyCustomDbDestination : BaseLoggingDestination<DbMetadata>{
 	//setup the connection to the database for example
 	private context _db;
 
-    public override void WriteLogEntry(T metadata, LogLevels level, string message = null, Exception thrownException = null)
-    {
+	public override void WriteLogEntry(T metadata, LogLevels level, string message = null, Exception thrownException = null)
+	{
 		//for any given log message, write all the details passed to the database record
 		_db.WriteLogRecord(message, level, metadata.UserId, metadata.EntryPointMethod, metadata.Permissions);
-    }
+	}
 }
 
 //example program usage
@@ -239,7 +236,7 @@ public void Main(string[] args){
 
 ## Running the unit tests
 
-The library is up to 44 unit tests currently.  I tried to cover everything possible.  They are created with 
+The library is up to 48 unit tests currently.  I tried to cover everything possible.  They are created with 
 XUnit and utilize Moq for two tests.  The Test project is included in this repository, as well as an Example project.
 
 
@@ -257,7 +254,7 @@ who participated in this project.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE) file for details
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
 
 
 ##### P.S.


### PR DESCRIPTION
finished all the coding to support Destination creation using the string literal "Debug", or interger value 31, in addition to the enum LogLevels.Debug.

Setting and reading an enum value from a config file is more difficult than a string or integer, now a developer can code their destination and set it's reporting level straight from whatever configuration harness they are using.

#11 