### PR TITLE
Prophet/yml builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.3.0
+### Converted build/release pipelines into YML source files
+Project's build and release pipleines are now written in YML files that are checked into the source code.
+
 # v2.2.0
 ### Build target for Net 5.0
 Library now targets .Net 5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# v2.3.0
+# v3.0.0
 ### Converted build/release pipelines into YML source files
 Project's build and release pipleines are now written in YML files that are checked into the source code.
+Removed build targets for unsupported versions of .Net frameworks (removed netcoreapp1.0, netcoreapp1.1, netcoreapp2.0, netcoreapp2.2, netcoreapp3.0.)
+Removed UTF7 as a target filetype encoding for FileDestinations as this is obsolete, should be using UTF8.
 
 # v2.2.0
 ### Build target for Net 5.0

--- a/Logger.sln
+++ b/Logger.sln
@@ -9,9 +9,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProphetsWay.Logger.Test", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{80EF23D7-E1C1-4A81-BB42-8F144C5E47AC}"
 	ProjectSection(SolutionItems) = preProject
+		azure-pipelines.yml = azure-pipelines.yml
+		build-and-test.yml = build-and-test.yml
+		build-test-deploy-release.yml = build-test-deploy-release.yml
 		CHANGELOG.md = CHANGELOG.md
 		LICENSE = LICENSE
 		README.md = README.md
+		version-variables.yml = version-variables.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProphetsWay.Logger.Example", "ProphetsWay.Logger.Example\ProphetsWay.Logger.Example.csproj", "{F4E19CED-1BDC-4DBE-AC62-8D95DB14C535}"

--- a/ProphetsWay.Logger.Example/Program.cs
+++ b/ProphetsWay.Logger.Example/Program.cs
@@ -21,7 +21,7 @@ namespace ProphetsWay.Example
 			Logger.Error(ex2, "Another generic message about an error occuring. (friendly message to show a UI maybe?)");
 
 
-			var dest = new FileDestination("test.log", LogLevels.Warning, false, FileDestination.EncodingOptions.UTF7);
+			var dest = new FileDestination("test.log", LogLevels.Warning, false, FileDestination.EncodingOptions.UTF8);
 
 			var evtDest = new EventDestination(LogLevels.Debug);
 			evtDest.LoggingEvent += (sender, eventArgs) => { /* whatever you want to do with the message here */ };

--- a/ProphetsWay.Logger.Test/ProphetsWay.Logger.Test.csproj
+++ b/ProphetsWay.Logger.Test/ProphetsWay.Logger.Test.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<TargetFrameworks>
 			net45;net451;net452;net46;net461;net471;net48;
-			netstandard2.0;netstandard2.1;
 			netcoreapp2.1;netcoreapp3.1;
 			net50;
 		</TargetFrameworks>

--- a/ProphetsWay.Logger.Test/ProphetsWay.Logger.Test.csproj
+++ b/ProphetsWay.Logger.Test/ProphetsWay.Logger.Test.csproj
@@ -1,21 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>
 			net45;net451;net452;net46;net461;net471;net48;
 			netstandard2.0;netstandard2.1;
-			netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;netcoreapp3.0;netcoreapp3.1;
+			netcoreapp2.1;netcoreapp3.1;
 			net50;
 		</TargetFrameworks>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="5.6.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-		<PackageReference Include="Moq" Version="4.10.1" />
+		<PackageReference Include="FluentAssertions" Version="5.10.3" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+		<PackageReference Include="Moq" Version="4.16.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/ProphetsWay.Logger/LoggerDestinations/FileDestination.cs
+++ b/ProphetsWay.Logger/LoggerDestinations/FileDestination.cs
@@ -74,9 +74,6 @@ namespace ProphetsWay.Utilities.LoggerDestinations
 				case EncodingOptions.UTF32:
 					return Encoding.UTF32;
 
-				case EncodingOptions.UTF7:
-					return Encoding.UTF7;
-
 				case EncodingOptions.UTF8:
 					return Encoding.UTF8;
 
@@ -123,7 +120,6 @@ namespace ProphetsWay.Utilities.LoggerDestinations
 			ASCII,
 			BigEndianUnicode,
 			Unicode,
-			UTF7,
 			UTF8,
 			UTF32
 		}

--- a/ProphetsWay.Logger/ProphetsWay.Logger.csproj
+++ b/ProphetsWay.Logger/ProphetsWay.Logger.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>

--- a/ProphetsWay.Logger/ProphetsWay.Logger.csproj
+++ b/ProphetsWay.Logger/ProphetsWay.Logger.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>
 			net40;net45;net451;net452;net46;net461;net471;net48;
 			netstandard1.3;netstandard1.6;netstandard2.0;netstandard2.1;
-			netcoreapp2.2;netcoreapp2.1;netcoreapp2.0;netcoreapp1.1;netcoreapp1.0;netcoreapp3.0;netcoreapp3.1;
+			netcoreapp2.1;netcoreapp3.1;
 			net50;
 		</TargetFrameworks>
 		<RootNamespace>ProphetsWay.Utilities</RootNamespace>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,30 @@
+# .NET Desktop
+# Build and run tests for .NET Desktop or Windows classic desktop solutions.
+# Add steps that publish symbols, save build artifacts, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
+
+trigger:
+- master
+pr:
+  branches:
+    include:
+    - '*'
+
+
+variables:
+  MajorVersion: '2'
+  MinorVersion: '2'
+  PatchVersion: '0'
+
+
+stages:
+- template: build-test-deploy-release.yml
+  parameters:
+    vmImage: 'windows-latest'
+    repositoryName: 'ProphetManX/ProphetsWay.Logger'
+    targetProject: '**/ProphetsWay.Logger.csproj'
+    libraryName: 'Logger'
+    licenseUrl: 'https://opensource.org/licenses/MIT'
+    description: 'A simple and easy to use Logging library that allows for customizable outputs for log entries.'
+    
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
 
 variables:
   MajorVersion: '2'
-  MinorVersion: '2'
+  MinorVersion: '3'
   PatchVersion: '0'
 
 

--- a/build-and-test.yml
+++ b/build-and-test.yml
@@ -1,0 +1,19 @@
+parameters:
+  vmImage: 'windows-latest'
+
+steps:
+- task: DotNetCoreCLI@2
+  displayName: 'Build Solution'
+  inputs:
+    command: 'build'
+
+- task: VSTest@2
+  displayName: 'Run Unit Tests'
+  inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: |
+        **\*test*.dll
+        !**\*TestAdapter.dll
+        !**\obj\**
+    searchFolder: '$(System.DefaultWorkingDirectory)'
+    diagnosticsEnabled: true

--- a/build-test-deploy-release.yml
+++ b/build-test-deploy-release.yml
@@ -1,0 +1,238 @@
+parameters:
+  vmImage: 'windows-latest'
+  repositoryName: 'NO_DEFAULT'
+  targetProject: 'NO_DEFAULT'
+  libraryName: 'NO_DEFAULT'
+  licenseUrl: 'NO_DEFAULT'
+  description: 'NO_DEFAULT'
+
+stages:
+  - stage: PullRequest
+    displayName: Pull Request Stage
+    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+    jobs:
+    - job: PrBuild
+      displayName: PR Build
+      pool:
+        vmImage: ${{parameters.vmImage}}
+      
+      steps:
+      - template: build-and-test.yml
+        parameters:
+          vmImage: ${{parameters.vmImage}}
+
+  - stage: Build
+    displayName: Build Stage
+    condition: contains(variables['build.sourceBranch'], 'refs/heads/master')
+    variables:
+    - template: version-variables.yml
+
+    jobs:
+    - job: CiBuild
+      displayName: CI Build
+      pool:
+        vmImage: ${{parameters.vmImage}}
+
+      steps:
+      - task: Assembly-Info-NetCore@2
+        displayName: 'Set Assembly Info'
+        inputs:
+          Path: '$(Build.SourcesDirectory)'
+          FileNames: '${{parameters.targetProject}}'
+          InsertAttributes: true
+          FileEncoding: 'auto'
+          WriteBOM: false
+          PackageRequireLicenseAcceptance: true
+          PackageId: 'ProphetsWay.${{parameters.libraryName}}'
+          Authors: 'G. Gordon Nasseri'
+          Company: 'ProphetsWay'
+          Product: '${{parameters.libraryName}}'
+          Description: '${{parameters.description}}'
+          PackageLicenseUrl: '${{parameters.licenseUrl}}'
+          RepositoryUrl: 'https://github.com/ProphetManX/ProphetsWay.${{parameters.libraryName}}'
+          RepositoryType: 'GitHub'
+          VersionNumber: '$(SemanticVersion).$(Build.BuildId)'
+          FileVersionNumber: '$(SemanticVersion).$(Build.BuildId)'
+          InformationalVersion: '$(SemanticVersion)'
+          PackageVersion: '$(SemanticVersion)'
+          LogLevel: 'verbose'
+          FailOnWarning: false
+          DisableTelemetry: false
+
+      - template: build-and-test.yml
+        parameters:
+          vmImage: ${{parameters.vmImage}}
+
+      - task: DotNetCoreCLI@2
+        displayName: 'Assemble Alpha NuGet Package'
+        inputs:
+          command: 'pack'
+          packagesToPack: '${{parameters.targetProject}}'
+          packDirectory: '$(Build.ArtifactStagingDirectory)\alpha'
+          versioningScheme: 'byEnvVar'
+          versionEnvVar: 'AlphaVersion'
+
+      - task: DotNetCoreCLI@2
+        displayName: 'Assemble Beta NuGet Package'
+        inputs:
+          command: 'pack'
+          packagesToPack: '${{parameters.targetProject}}'
+          packDirectory: '$(Build.ArtifactStagingDirectory)\beta'
+          versioningScheme: 'byEnvVar'
+          versionEnvVar: 'BetaVersion'
+
+      - task: DotNetCoreCLI@2
+        displayName: 'Assemble Release NuGet Package'
+        inputs:
+          command: 'pack'
+          packagesToPack: '${{parameters.targetProject}}'
+          packDirectory: '$(Build.ArtifactStagingDirectory)\release'
+          versioningScheme: 'byEnvVar'
+          versionEnvVar: 'SemanticVersion'
+
+      - task: CopyFiles@2
+        displayName: 'Copy Changelog to Staging'
+        inputs:
+          Contents: 'CHANGELOG.md'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)\'
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts'
+        inputs:
+          PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          ArtifactName: 'drop'
+          publishLocation: 'Container'
+
+  - stage: DeployAlpha
+    displayName: Deploy Alpha NuGet Package
+    dependsOn: Build
+    condition: and(succeeded('Build'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    jobs:
+    - job: DeployAlpha
+      displayName: 'Deploy Alpha NuGet Package Job'
+      continueOnError: "true"
+      pool:
+        vmImage: ${{parameters.vmImage}}
+      steps:
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Artifact
+        inputs:
+          buildType: 'current'
+          downloadType: 'single'
+          artifactName: 'drop'
+          downloadPath: '$(build.artifactstagingdirectory)'
+
+      - task: NuGetCommand@2
+        displayName: 'Push Alpha NuGet Package'
+        inputs:
+          command: 'push'
+          packagesToPush: '$(build.artifactstagingdirectory)/drop/alpha/*.nupkg'
+          nuGetFeedType: 'external'
+          publishFeedCredentials: 'ProphetManX''s NuGet'
+
+  - stage: DeployBeta
+    displayName: Deploy Beta NuGet Package
+    dependsOn: DeployAlpha
+    condition: and(succeeded('DeployAlpha'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    variables:
+    - template: version-variables.yml
+
+    jobs:
+    - deployment: DeployBeta
+      displayName: 'Deploy Beta NuGet Package Job'
+      continueOnError: "false"
+      pool:
+        vmImage: ${{parameters.vmImage}}
+      environment: '${{parameters.libraryName}} Beta NuGet'
+      strategy: 
+        runOnce:
+          deploy:
+            steps:
+            - task: DownloadBuildArtifacts@0
+              displayName: Download Artifact
+              inputs:
+                buildType: 'current'
+                downloadType: 'single'
+                artifactName: 'drop'
+                downloadPath: '$(build.artifactstagingdirectory)'
+
+            - task: GitHubRelease@1
+              displayName: 'Create GitHub Beta Release'
+              inputs:
+                gitHubConnection: 'ProphetsWay@GitHub'
+                repositoryName: '${{parameters.repositoryName}}'
+                action: 'create'
+                target: '$(Build.SourceVersion)'
+                tagSource: 'userSpecifiedTag'
+                tag: '$(BetaVersion)'
+                title: '$(BetaVersion)'
+                releaseNotesFilePath: '$(build.artifactstagingdirectory)/drop/changelog.md'
+                assets: '$(build.artifactstagingdirectory)/drop/beta/*.nupkg'
+                isPreRelease: true
+                changeLogCompareToRelease: 'lastFullRelease'
+                changeLogType: 'commitBased'
+
+            - task: NuGetCommand@2
+              displayName: 'Push Beta NuGet Package'
+              inputs:
+                command: 'push'
+                packagesToPush: '$(build.artifactstagingdirectory)/drop/beta/*.nupkg'
+                nuGetFeedType: 'external'
+                publishFeedCredentials: 'ProphetManX''s NuGet'
+
+  - stage: DeployRelease
+    displayName: Deploy Release NuGet Package
+    dependsOn: DeployBeta
+    condition: and(succeeded('DeployBeta'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    variables:
+    - template: version-variables.yml
+
+    jobs:
+    - deployment: DeployRelease
+      displayName: 'Deploy Release NuGet Package Job'
+      continueOnError: "false"
+      pool:
+        vmImage: ${{parameters.vmImage}}
+      environment: '${{parameters.libraryName}} Release NuGet'
+      strategy: 
+        runOnce:
+          deploy:
+            steps:
+            - task: DownloadBuildArtifacts@0
+              displayName: Download Artifact
+              inputs:
+                buildType: 'current'
+                downloadType: 'single'
+                artifactName: 'drop'
+                downloadPath: '$(build.artifactstagingdirectory)'
+
+            - task: GitHubRelease@1
+              displayName: 'Delete GitHub Beta Release'
+              inputs:
+                gitHubConnection: 'ProphetsWay@GitHub'
+                repositoryName: '${{parameters.repositoryName}}'
+                action: 'delete'
+                tag: '$(BetaVersion)'
+
+            - task: GitHubRelease@1
+              displayName: 'Create GitHub Release'
+              inputs:
+                gitHubConnection: 'ProphetsWay@GitHub'
+                repositoryName: '${{parameters.repositoryName}}'
+                action: 'create'
+                target: '$(Build.SourceVersion)'
+                tagSource: 'userSpecifiedTag'
+                tag: '$(SemanticVersion)'
+                title: '$(SemanticVersion)'
+                releaseNotesFilePath: '$(build.artifactstagingdirectory)/drop/changelog.md'
+                assets: '$(build.artifactstagingdirectory)/drop/release/*.nupkg'
+                changeLogCompareToRelease: 'lastFullRelease'
+                changeLogType: 'commitBased'
+
+            - task: NuGetCommand@2
+              displayName: 'Push Release NuGet Package'
+              inputs:
+                command: 'push'
+                packagesToPush: '$(build.artifactstagingdirectory)/drop/release/*.nupkg'
+                nuGetFeedType: 'external'
+                publishFeedCredentials: 'ProphetManX''s NuGet'

--- a/version-variables.yml
+++ b/version-variables.yml
@@ -1,0 +1,5 @@
+# basic variable constructs that are going to be used across multiple projects
+variables:
+  SemanticVersion: '$(MajorVersion).$(MinorVersion).$(PatchVersion)'
+  AlphaVersion: '$(SemanticVersion)-$(Build.BuildId).Alpha'
+  BetaVersion: '$(SemanticVersion)-$(Build.BuildId).Beta'


### PR DESCRIPTION
converting the build pipelines to yml
removing references for older build targets that are no longer supported by Microsoft
also removed UTF7 as an option as it is obsolete
closes #14 